### PR TITLE
Replace money_format with number_format

### DIFF
--- a/src/model/OrderItem.php
+++ b/src/model/OrderItem.php
@@ -89,7 +89,7 @@ class OrderItem extends DataObject
 
     public function UnitPrice()
     {
-        return  $this->Variant()->exists() ? '$' . money_format('%i',  $this->Variant()->Price) : '-';
+        return  $this->Variant()->exists() ? '$' . number_format($this->Variant()->Price,2) : '-';
     }
 
     public function getData()


### PR DESCRIPTION
money_format has been DEPRECATED as of PHP 7.4.0.