### PR TITLE
Fix the duplicate fields with subsite module

### DIFF
--- a/src/model/ProductCollection.php
+++ b/src/model/ProductCollection.php
@@ -96,7 +96,7 @@ class ProductCollection extends Page
 
         $this->add_pagesize_field($fields);
 
-        $this->extend('updateCMSFields', $fields);
+        // $this->extend('updateCMSFields', $fields); // This line will cause duplicate fields with subsite module.
 
         return $fields;
     }


### PR DESCRIPTION
This line has a conflict with the SilverStripe subsite module this line

https://github.com/silverstripe/silverstripe-subsites/blob/0fe63e92bd9a360471880bf4849f18de612aa0c1/src/Extensions/SiteTreeSubsites.php#L125

If there is a page extended with ProductCollection class and SilverStripe subsite module will insert the SubsiteOperations twice and cause this issue
```
[Emergency] Uncaught RuntimeException: SilverStripe\Forms\{closure}() I noticed that a field called 'CopyToSubsiteID' appears twice
```

Although I think it is SilverStripe subsite module's issue, they should check if the fields exist or not before inserting them. But I don't think they will fix this issue soon. I will submit a PR in their repo as well.